### PR TITLE
Add Pagination

### DIFF
--- a/backend/routes/posts.js
+++ b/backend/routes/posts.js
@@ -47,8 +47,14 @@ router.post("", multer({storage: storage}).single("image"), (req, res, next) => 
 });
 
 router.get("", (req, res, next) => {
-  Post.find()
-    .then(documents => {
+  const pageSize = +req.query.pageSize;
+  const currentPage = +req.query.currentPage;
+  const postQuery = Post.find();
+  if(pageSize && currentPage) {
+    postQuery.skip(pageSize * (currentPage - 1))
+    .limit(pageSize);
+  }
+  postQuery.then(documents => {
       res.status(200).json({
         message: 'Posts fetched successfully',
         posts: documents

--- a/backend/routes/posts.js
+++ b/backend/routes/posts.js
@@ -50,16 +50,21 @@ router.get("", (req, res, next) => {
   const pageSize = +req.query.pageSize;
   const currentPage = +req.query.currentPage;
   const postQuery = Post.find();
+  let fetchedPosts;
   if(pageSize && currentPage) {
     postQuery.skip(pageSize * (currentPage - 1))
     .limit(pageSize);
   }
   postQuery.then(documents => {
-      res.status(200).json({
-        message: 'Posts fetched successfully',
-        posts: documents
-      });
+    fetchedPosts = documents;
+    return Post.countDocuments();
+  }).then(count => {
+    res.status(200).json({
+      message: 'Posts fetched successfully',
+      posts: fetchedPosts,
+      maxPosts: count
     });
+  });
 });
 
 router.get("/:id", (req, res, next) => {

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -9,6 +9,7 @@ import { MatButtonModule } from '@angular/material/button';
 import { MatToolbarModule } from '@angular/material/toolbar';
 import { MatExpansionModule } from '@angular/material/expansion';
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
+import { MatPaginatorModule } from '@angular/material/paginator';
 import { HttpClientModule } from '@angular/common/http';
 
 import { AppComponent } from './app.component';
@@ -35,6 +36,7 @@ import { PostsService } from './posts/posts.service';
     MatToolbarModule,
     MatExpansionModule,
     MatProgressSpinnerModule,
+    MatPaginatorModule,
     HttpClientModule
   ],
   providers: [

--- a/src/app/posts/post-create/post-create.component.html
+++ b/src/app/posts/post-create/post-create.component.html
@@ -11,7 +11,7 @@
       <button type="button" mat-stroked-button color="primary" (click)="imagePicker.click()">Select Image</button>
       <input type="file" #imagePicker (change)="onImageSelected($event)">
     </div>
-    <div *ngIf="imagePreview !== '' && imagePreview &&!form.get('image').valid">Invalid file</div>
+    <div *ngIf="imagePreview !== '' && imagePreview && !form.get('image').valid">Invalid file</div>
     <div class="image-preview" *ngIf="imagePreview !== '' && imagePreview && form.get('image').valid">
       <img [src]="imagePreview" alt="form.value.title">
     </div>

--- a/src/app/posts/post-list/post-list.component.html
+++ b/src/app/posts/post-list/post-list.component.html
@@ -17,5 +17,12 @@
     </mat-action-row>
 
   </mat-expansion-panel>
+  <mat-paginator
+    [length]="totalPosts"
+    [pageSize]="postsPerPage"
+    [pageSizeOptions]="pageSizeOptions"
+    (page) = "onPageChanged($event)"
+    >
+  </mat-paginator>
 </mat-accordion>
 <p *ngIf="posts.length <= 0 && !isLoading" class="info-text mat-body-1">No posts added yet.</p>

--- a/src/app/posts/post-list/post-list.component.html
+++ b/src/app/posts/post-list/post-list.component.html
@@ -17,12 +17,12 @@
     </mat-action-row>
 
   </mat-expansion-panel>
-  <mat-paginator
-    [length]="totalPosts"
-    [pageSize]="postsPerPage"
-    [pageSizeOptions]="pageSizeOptions"
-    (page) = "onPageChanged($event)"
-    >
-  </mat-paginator>
 </mat-accordion>
+<mat-paginator
+  [length]="totalPosts"
+  [pageSize]="postsPerPage"
+  [pageSizeOptions]="pageSizeOptions"
+  (page) = "onPageChanged($event)"
+  *ngIf="posts.length > 0">
+</mat-paginator>
 <p *ngIf="posts.length <= 0 && !isLoading" class="info-text mat-body-1">No posts added yet.</p>

--- a/src/app/posts/post-list/post-list.component.ts
+++ b/src/app/posts/post-list/post-list.component.ts
@@ -11,14 +11,10 @@ import { PostsService } from '../posts.service';
   styleUrls: ['./post-list.component.css']
 })
 export class PostListComponent implements OnInit, OnDestroy {
-  // posts = [
-  //   {title: 'First Post Title', content: 'This is first post\'s content'},
-  //   {title: 'Second Post Title', content: 'This is second post\'s content'},
-  //   {title: 'Third Post Title', content: 'This is third post\'s content'}
-  // ];
   posts: Post[] = [];
   isLoading = false;
   totalPosts = 10;
+  currentPage = 1;
   postsPerPage = 2;
   pageSizeOptions = [1, 2, 5, 10];
   private postsSub: Subscription;
@@ -29,7 +25,7 @@ export class PostListComponent implements OnInit, OnDestroy {
 
   ngOnInit(): void {
     this.isLoading = true;
-    this.postsService.getPosts();
+    this.postsService.getPosts(this.postsPerPage, this.currentPage);
     this.postsSub = this.postsService.getPostUpdateListener()
       .subscribe((posts: Post[]) => {
         this.isLoading = false;
@@ -46,7 +42,9 @@ export class PostListComponent implements OnInit, OnDestroy {
   }
 
   onPageChanged(pageEvent: PageEvent) {
-    console.log(pageEvent)
+    this.currentPage = pageEvent.pageIndex + 1;
+    this.postsPerPage = pageEvent.pageSize;
+    this.postsService.getPosts(this.postsPerPage, this.currentPage);
   }
 
 }

--- a/src/app/posts/post-list/post-list.component.ts
+++ b/src/app/posts/post-list/post-list.component.ts
@@ -1,4 +1,5 @@
 import { Component, OnDestroy, OnInit } from '@angular/core';
+import { PageEvent } from '@angular/material/paginator';
 import { Subscription } from 'rxjs';
 
 import { Post } from '../post.model';
@@ -17,6 +18,9 @@ export class PostListComponent implements OnInit, OnDestroy {
   // ];
   posts: Post[] = [];
   isLoading = false;
+  totalPosts = 10;
+  postsPerPage = 2;
+  pageSizeOptions = [1, 2, 5, 10];
   private postsSub: Subscription;
 
   constructor(
@@ -40,4 +44,9 @@ export class PostListComponent implements OnInit, OnDestroy {
   onDelete(postId){
     this.postsService.deletePost(postId);
   }
+
+  onPageChanged(pageEvent: PageEvent) {
+    console.log(pageEvent)
+  }
+
 }

--- a/src/app/posts/post-list/post-list.component.ts
+++ b/src/app/posts/post-list/post-list.component.ts
@@ -13,7 +13,7 @@ import { PostsService } from '../posts.service';
 export class PostListComponent implements OnInit, OnDestroy {
   posts: Post[] = [];
   isLoading = false;
-  totalPosts = 10;
+  totalPosts = 0;
   currentPage = 1;
   postsPerPage = 2;
   pageSizeOptions = [1, 2, 5, 10];
@@ -26,10 +26,12 @@ export class PostListComponent implements OnInit, OnDestroy {
   ngOnInit(): void {
     this.isLoading = true;
     this.postsService.getPosts(this.postsPerPage, this.currentPage);
-    this.postsSub = this.postsService.getPostUpdateListener()
-      .subscribe((posts: Post[]) => {
+    this.postsSub = this.postsService
+      .getPostUpdateListener()
+      .subscribe((postsData: {posts: Post[], postsCount: number}) => {
         this.isLoading = false;
-        this.posts = posts;
+        this.totalPosts = postsData.postsCount;
+        this.posts = postsData.posts;
       });
   }
 
@@ -38,10 +40,15 @@ export class PostListComponent implements OnInit, OnDestroy {
   }
 
   onDelete(postId){
-    this.postsService.deletePost(postId);
+    this.isLoading = true;
+    this.postsService.deletePost(postId)
+      .subscribe(() => {
+        this.postsService.getPosts(this.postsPerPage, this.currentPage);
+      });
   }
 
   onPageChanged(pageEvent: PageEvent) {
+    this.isLoading = true;
     this.currentPage = pageEvent.pageIndex + 1;
     this.postsPerPage = pageEvent.pageSize;
     this.postsService.getPosts(this.postsPerPage, this.currentPage);

--- a/src/app/posts/posts.service.ts
+++ b/src/app/posts/posts.service.ts
@@ -9,7 +9,7 @@ import { Post } from './post.model';
 @Injectable({providedIn: 'root'})
 export class PostsService {
   private posts: Post[] = [];
-  private postsUpdated = new Subject<Post[]>();
+  private postsUpdated = new Subject<{posts: Post[], postsCount: number}>();
 
   constructor(
     private http: HttpClient,
@@ -18,20 +18,25 @@ export class PostsService {
 
   getPosts(postsPerPage: number, currentPage: number){
     const queryParams = `?pageSize=${postsPerPage}&currentPage=${currentPage}`;
-    this.http.get<{message: string, posts: any}>("http://localhost:3002/api/posts" + queryParams)
+    this.http.get<{message: string, posts: any, maxPosts: number}>("http://localhost:3002/api/posts" + queryParams)
       .pipe(map((resData) => {
-        return resData.posts.map(post => {
+        return {
+        posts: resData.posts.map(post => {
           return {
             id: post._id,
             title: post.title,
             content: post.content,
             imagePath: post.imagePath
           };
-        });
+        }),
+        maxPosts: resData.maxPosts};
       }))
       .subscribe((postsData) => {
-        this.posts = postsData;
-        this.postsUpdated.next([...this.posts]);
+        this.posts = postsData.posts;
+        this.postsUpdated.next({
+          posts: [...this.posts],
+          postsCount: postsData.maxPosts
+        });
       });
   }
 
@@ -55,14 +60,6 @@ export class PostsService {
       postData
       )
       .subscribe((resData) => {
-        const post: Post = {
-          "id": resData.post.id,
-          "title": resData.post.title,
-          "content": resData.post.content,
-          "imagePath": resData.post.imagePath
-        };
-        this.posts.push(post);
-        this.postsUpdated.next([...this.posts]);
         this.router.navigate(['/']);
       });
   }
@@ -83,29 +80,12 @@ export class PostsService {
         imagePath: image
       }
     }
-    //const post: Post = { id: id, title: title, content: content, imagePath: null };
     this.http.put("http://localhost:3002/api/posts/" + id, postData)
       .subscribe(response => {
-        const updatedPosts = [...this.posts];
-        const oldPostIndex = updatedPosts.findIndex(p => p.id === id);
-        const post: Post = {
-        id: id,
-        title: title,
-        content: content,
-        imagePath: ""
-        }
-        updatedPosts[oldPostIndex] = post;
-        this.posts = updatedPosts;
-        this.postsUpdated.next([...updatedPosts]);
         this.router.navigate(['/']);
       });
   }
   deletePost(postId: string) {
-    this.http.delete("http://localhost:3002/api/posts/"+postId)
-      .subscribe(() => {
-        const postsAfterDel = this.posts.filter(post => post.id !== postId);
-        this.posts = postsAfterDel;
-        this.postsUpdated.next([...this.posts]);
-      });
+    return this.http.delete("http://localhost:3002/api/posts/" + postId);
   }
 }

--- a/src/app/posts/posts.service.ts
+++ b/src/app/posts/posts.service.ts
@@ -16,8 +16,9 @@ export class PostsService {
     private router: Router
   ) {}
 
-  getPosts(){
-    this.http.get<{message: string, posts: any}>("http://localhost:3002/api/posts")
+  getPosts(postsPerPage: number, currentPage: number){
+    const queryParams = `?pageSize=${postsPerPage}&currentPage=${currentPage}`;
+    this.http.get<{message: string, posts: any}>("http://localhost:3002/api/posts" + queryParams)
       .pipe(map((resData) => {
         return resData.posts.map(post => {
           return {


### PR DESCRIPTION
Add Angular Material paginator.
Add backend support for pagination.
Connect Angular paginator to backend 

-   send requests with params (page size and posts per page) to fetch the required posts only.

-   fetch posts count in response to display correct numbers of pages and posts per page.

Update paginator posts and page count on post deletion.
