### PR TITLE
Persist user authentication status

### DIFF
--- a/backend/routes/user.js
+++ b/backend/routes/user.js
@@ -52,7 +52,8 @@ router.post("/login", (req, res, next) => {
         { expiresIn: "1h" }
       );
       res.status(201).json({
-        token: token
+        token: token,
+        expiresIn: 3600
       });
     })
     .catch(err => {

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,9 +1,15 @@
-import { Component } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
+import { AuthService } from './auth/auth.service';
 
 @Component({
   selector: 'app-root',
   templateUrl: './app.component.html',
   styleUrls: ['./app.component.css']
 })
-export class AppComponent {
+export class AppComponent implements OnInit {
+  constructor(private authService: AuthService) {}
+
+  ngOnInit(): void {
+    this.authService.autoAuthUser();
+  }
 }

--- a/src/app/auth/auth.service.ts
+++ b/src/app/auth/auth.service.ts
@@ -49,14 +49,30 @@ export class AuthService {
         this.token = resToken;
         if(resToken) {
           const expirationDuration = response.expiresIn;
-          this.tokenTimer = setTimeout(() => {
-            this.logout();
-          }, expirationDuration * 1000);
+          this.setAuthTimer(expirationDuration);
           this.isAuthenticated = true;
           this.authStatusListener.next(true);
+          const now = new Date();
+          const expirationDate = new Date(now.getTime() + expirationDuration * 1000);
+          this.saveAuthData(this.token, expirationDate);
           this.router.navigate(['/']);
         }
       });
+  }
+
+  autoAuthUser(){
+    const authInformation = this.getAuthData();
+    if(!authInformation) {
+      return;
+    }
+    const now = new Date();
+    const expiresIn = authInformation.expirationDate.getTime() - now.getTime();
+    if(expiresIn > 0) {
+      this.token = authInformation.token;
+      this.setAuthTimer(expiresIn / 1000);
+      this.isAuthenticated = true;
+      this.authStatusListener.next(true);
+    }
   }
 
   logout() {
@@ -64,7 +80,36 @@ export class AuthService {
     this.isAuthenticated = false;
     this.authStatusListener.next(false);
     clearTimeout(this.tokenTimer);
+    this.clearAuthData();
     this.router.navigate(['/']);
+  }
+
+  private setAuthTimer(duration: number) {
+    this.tokenTimer = setTimeout(() => {
+      this.logout();
+    }, duration * 1000);
+  }
+
+  private saveAuthData(token: string, expirationDate: Date) {
+    localStorage.setItem("token", token);
+    localStorage.setItem("expiration", expirationDate.toISOString());
+  }
+
+  private clearAuthData() {
+    localStorage.removeItem("token");
+    localStorage.removeItem("expiration");
+  }
+
+  private getAuthData() {
+    const token = localStorage.getItem("token");
+    const expirationDate = localStorage.getItem("expiration");
+    if(!token || !expirationDate) {
+      return;
+    }
+    return {
+      token: token,
+      expirationDate: new Date(expirationDate)
+    }
   }
 
 }

--- a/src/app/header/header.component.ts
+++ b/src/app/header/header.component.ts
@@ -15,6 +15,7 @@ export class HeaderComponent implements OnInit, OnDestroy {
   constructor( private authService: AuthService) { }
 
   ngOnInit(): void {
+    this.userIsAuthenticated = this.authService.getIsAuth();
     this.authListenerSub = this.authService.getAuthStatusListener()
       .subscribe(isAuthenticated => {
         this.userIsAuthenticated = isAuthenticated;


### PR DESCRIPTION
Automatically logout the user after 1 hour.
Save user auth information in local storage to persist authentication status.
Secure the user login/logout status on revisits or page reloads.